### PR TITLE
Replace toBeTruthy with toEqual(true)

### DIFF
--- a/src/tests/fica.test.ts
+++ b/src/tests/fica.test.ts
@@ -30,17 +30,17 @@ describe('fica', () => {
       fc.property(arbitraries.f1040, ([f1040, forms]) => {
         if (f1040.w2s.length <= 1) {
           // Should never give SS refund with 1 or fewer W2s
-          expect(!hasSSRefund(f1040)).toBeTruthy()
+          expect(!hasSSRefund(f1040)).toEqual(true)
         } else {
           if (f1040.wages() <= fica.maxIncomeSSTaxApplies ||
             f1040.w2s.some((w2) => w2.ssWithholding > fica.maxSSTax)) {
             // Should never give SS refund if W2 income below max threshold, or
             // some W2 has withheld over the max.
-            expect(!hasSSRefund(f1040)).toBeTruthy()
+            expect(!hasSSRefund(f1040)).toEqual(true)
           } else {
             // Otherwise, should always give SS refund, and attach schedule 3
-            expect(hasSSRefund(f1040)).toBeTruthy()
-            expect(hasAttachment(forms, Schedule3)).toBeTruthy()
+            expect(hasSSRefund(f1040)).toEqual(true)
+            expect(hasAttachment(forms, Schedule3)).toEqual(true)
           }
         }
       })
@@ -71,14 +71,14 @@ describe('fica', () => {
         const filingStatus = f1040.filingStatus
         // Should add Additional Medicare Tax iff wages over threshold
         if (f1040.wages() > fica.additionalMedicareTaxThreshold(filingStatus)) {
-          expect(hasAdditionalMedicareTax(f1040)).toBeTruthy()
+          expect(hasAdditionalMedicareTax(f1040)).toEqual(true)
 
           // Should attach both S2 and F8959 to return
-          expect(hasAttachment(forms, Schedule2)).toBeTruthy()
-          expect(hasAttachment(forms, F8959)).toBeTruthy()
+          expect(hasAttachment(forms, Schedule2)).toEqual(true)
+          expect(hasAttachment(forms, F8959)).toEqual(true)
         } else {
-          expect(!hasAdditionalMedicareTax(f1040)).toBeTruthy()
-          expect(!hasAttachment(forms, F8959)).toBeTruthy()
+          expect(!hasAdditionalMedicareTax(f1040)).toEqual(true)
+          expect(!hasAttachment(forms, F8959)).toEqual(true)
         }
       })
     )


### PR DESCRIPTION
PR looks great, I just wanted to suggest instead of `toBeTruthy` we use `toEqual(true)`. The main reason `toBeTruthy` even exists is that jest is first and foremost a javascript library.

[From the docs](https://jestjs.io/docs/expect#tobetruthy):

> Use `.toBeTruthy` when you don't care what a value is and you want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
> ...
> In JavaScript, there are six falsy values: false, 0, '', null, undefined, and NaN. Everything else is truthy.

So in our context, if we are testing a function that's supposed to return a true/false, and for some reason, after being compiled to JS, at runtime it returns a non-empty string for example, we would definitely like the test to fail.
